### PR TITLE
ha3g: Fix the LibLights color inputs

### DIFF
--- a/liblights/lights.c
+++ b/liblights/lights.c
@@ -207,6 +207,7 @@ static int set_light_leds(const struct light_state_t *state, int type)
     struct led_config led;
     unsigned int colorRGB;
 
+    colorRGB = (colorRGB & 0x00FFFFFF) | 0xFF000000;
     colorRGB = get_dimmed_color(state, 200);
 
     switch (state->flashMode) {
@@ -248,6 +249,7 @@ static int set_light_battery(struct light_device_t *dev,
     int brightness = rgb_to_brightness(state);
     unsigned int colorRGB;
 
+    colorRGB = (colorRGB & 0x00FFFFFF) | 0xFF000000;
     colorRGB = get_dimmed_color(state, 20);
 
     if (brightness == 0) {


### PR DESCRIPTION
In reference to :
   https://github.com/CyanogenMod/android_frameworks_base/commit/b180ab8e12e7b50374f5bfb50f4bb97faad82f21#commitcomment-13840709

Why :
  The D/lights  ( 2782): set_light_battery 0xd00 0 0 you can means the colorRBG is not filtered correctly.
  Attempt fixing it by making sure the value doesn't overflow.
